### PR TITLE
fix(starters): don't commit *.Rproj files

### DIFF
--- a/starters/homework-1/.gitignore
+++ b/starters/homework-1/.gitignore
@@ -11,7 +11,6 @@ homework_1_files/bootstrap-*/*
 homework_1_files/jquery-*/*
 homework_1_files/navigation-*/*
 homework_1_files/figure-html/
-*.Rproj
 
 # ---------------------------
 # BEGIN ignore basic files
@@ -120,9 +119,10 @@ Session.vim
 tags
 
 # rstudio
-.Rproj.user
+*.Rproj
 *.knit.md
 *.utf8.md
+.Rproj.user
 rsconnect
 *_cache/
 cache/

--- a/starters/lab-01/.gitignore
+++ b/starters/lab-01/.gitignore
@@ -119,9 +119,10 @@ Session.vim
 tags
 
 # rstudio
-.Rproj.user
+*.Rproj
 *.knit.md
 *.utf8.md
+.Rproj.user
 rsconnect
 *_cache/
 cache/

--- a/starters/lab-02/.gitignore
+++ b/starters/lab-02/.gitignore
@@ -119,9 +119,10 @@ Session.vim
 tags
 
 # rstudio
-.Rproj.user
+*.Rproj
 *.knit.md
 *.utf8.md
+.Rproj.user
 rsconnect
 *_cache/
 cache/

--- a/starters/mini-homework-2a/.gitignore
+++ b/starters/mini-homework-2a/.gitignore
@@ -119,9 +119,10 @@ Session.vim
 tags
 
 # rstudio
-.Rproj.user
+*.Rproj
 *.knit.md
 *.utf8.md
+.Rproj.user
 rsconnect
 *_cache/
 cache/

--- a/starters/mini-homework-2b/.gitignore
+++ b/starters/mini-homework-2b/.gitignore
@@ -119,9 +119,10 @@ Session.vim
 tags
 
 # rstudio
-.Rproj.user
+*.Rproj
 *.knit.md
 *.utf8.md
+.Rproj.user
 rsconnect
 *_cache/
 cache/

--- a/starters/mini-homework-3/.gitignore
+++ b/starters/mini-homework-3/.gitignore
@@ -119,9 +119,10 @@ Session.vim
 tags
 
 # rstudio
-.Rproj.user
+*.Rproj
 *.knit.md
 *.utf8.md
+.Rproj.user
 rsconnect
 *_cache/
 cache/


### PR DESCRIPTION
The `.gitignore` files for all available starter templates have been updated to prevent students from accidentally committing their RStudio Project files to GitHub. When this was allowed, it led to unnecessary merge conflicts when students work in groups, so it's just easier to prevent it from happening in the first place.