### PR TITLE
content(labs): update and revise lab 8

### DIFF
--- a/content/Labs/lab08-speed-of-light.Rmd
+++ b/content/Labs/lab08-speed-of-light.Rmd
@@ -11,13 +11,20 @@ Show_link: true
 ```{r setup, include = FALSE}
 suppressPackageStartupMessages(library(tidyverse))
 
-icon_pdf <- '<i class="fas fa-file-pdf" data-fa-transform="grow-16"></i>&nbsp;'
+icon_pdf <- '<i class="fas fa-file-pdf" data-fa-transform="grow-2"></i>&nbsp;'
+icon_link <- '<i class="fas fa-link"></i>'
 icon_github <- '<i class="fab fa-github-alt" data-fa-transform="grow-16"></i>&nbsp;'
+icon_link_bullet <- '<i class="fas fa-link" data-fa-transform="grow-2"></i>&nbsp;'
 lab_name <- "Lab 8"
+starter_file <- "lab08.Rmd"
 ```
 
-> This week's lab will show you how to apply statistical methods and resampling techniques to a dataset from the natural sciences, Simon Newcomb's measurements of the speed of light.
-> Through this, we will see how statistical methods can help us to put the scientific method into practice and provide you with hands-on experience with the kinds of data analysis a scientist will use after completing a series of experimental measurements.
+## Instructions
+
+Obtain the GitHub repository you will use to complete the lab, which contains a starter file named [`r starter_file`]{.monospace}.
+This lab shows you how to apply statistical methods and resampling techniques to a dataset from the natural sciences, Simon Newcomb's measurements of the speed of light.
+Carefully read the lab instructions and complete the exercises using the provided spaces within your starter file [`r starter_file`]{.monospace}.
+Then, when you're ready to submit, follow the directions in the [`r icon_link`How to submit](#how-to-submit) section below.
 
 ## Natural science, data science
 
@@ -25,24 +32,53 @@ Many of the datasets we've worked through in our labs this semester have come fr
 That doesn't mean that the skills we're building don't have a useful application in fields such as physics, chemistry, and biology.
 For that reason, this week we will apply statistical methods to a dataset from the natural sciences that can be used to calculate the speed of light.
 
-## About this week's dataset
+## About the dataset
 
 The astronomer and applied mathematician Simon Newcomb collected this dataset over three separate days between the dates of July 24, 1882 and September 5, 1882[@stigler:robust; @Newcomb:1882] in Washington, DC.
 He performed the measurements using an apparatus design similar to Léon Foucault's system of rotating mirrors[@jaffe:1960], which allowed Newcomb to measure the time it took a beam of light to travel from Fort Myer on the west bank of the Potomac to a mirror located at the Washington monument and back[@stigler:robust; @Carter:2002], corresponding to a distance of 7443.73 meters.
-This dataset contains 66 observations, which have been transformed so that the dataset could be analyzed as a series of integers.
-To convert a dataset value $t$ to the actual transit time $t_{meas}$ in seconds, use the formula,
 
-\\[\text{t}_{\text{meas}}=\dfrac{\dfrac{\text{t}}{1000}+24.8}{1000000}\\]
+The table below provides descriptions of the dataset's 2 variables,
+
+| Variable            | Description                                                        |
+| ---------           | ------------------------------------------------------------------ |
+| [trial]{.monospace} | The experimental trial number                                      |
+| [time]{.monospace}  | The observed time it took a beam of light to travel 7443.73 meters |
+
+::: {.callout .primary}
+[Note]{.h4}
+
+The time measurements have been transformed so that the values could be logged as a series of integers.
+To convert a [time]{.monospace} value from the dataset back to the actual transit time [time<sub>meas</sub>]{.monospace} in seconds, use the formula,
+
+\\[\text{time}_{\text{meas}}=\dfrac{\dfrac{\text{time}}{1000}+24.8}{1000000}\\]
+:::
 
 ## Visualizing and quantifying the distribution
 
 Let's start by doing the usual practice of getting to know our dataset.
-There's only one relevant variable in this dataset, [time]{.monospace}, so it's the distribution of the measured times that matter.
-Let's appraise the distribution of time measurements by creating some visualizations:
+Since there's only one relevant variable in this dataset, [time]{.monospace}, let's appraise the distribution of time measurements by creating some visualizations:
 
 @.
-    Visualize the dataset distribution as a boxplot --- use `geom_boxplot(aes(x = "unfiltered", y = time)) + coord_flip()` --- and as a probability mass function (PMF) --- use `geom_histogram()` with [y = ..density..]{.monospace} inside `aes()` --- with a binwidth that allows you can see the full dataset (only identical numbers should have counts larger than 1).
-    Describe the center, shape, and spread of the distribution (don't forget to mention the outliers).
+    Visualize the [time]{.monospace} distribution as a boxplot,
+    
+    ```r
+    ggplot(newcomb) +
+      geom_boxplot(
+        mapping = aes(x = "unfiltered", y = time)
+      ) +
+      coord_flip()
+    ```
+    
+    Then, for a different perspective, visualize the [time]{.monospace} distribution as a **probability mass function (PMF)**.
+    
+    Describe the center, shape, and spread of the distribution (don't forget to mention any outliers you see).
+    
+    ::: {.callout .primary}
+    [Hint]{.h4}
+    
+    The probability mass function can be created using `geom_histogram()` and by setting [y = ..density..]{.monospace} inside the `aes()` function.
+    Make sure that you choose a binwidth that allows you to see the full dataset, meaning only identical numbers should have counts larger than 1!
+    :::
 
 One of the things you'll immediately notice when visualizing this dataset is how pronounced the outliers are.
 The experimental setup involved a rapidly rotating mirror that had to be precisely tuned.
@@ -53,8 +89,9 @@ Thus, the best choice is to analyze two versions of the dataset, one with the ou
 
 @.
     Create a second, filtered version of the dataset that removes the outliers that you see in the distribution.
+    Name this dataset [newcomb\_no_outliers]{.monospace}.
 
-Another useful visualization for understanding a dataset is the cumulative distribution function (CDF), which creates a map from the distribution's values to their respective percentiles.
+Another useful visualization for understanding a dataset is the cumulative distribution function (CDF), which maps a distribution's values to their respective percentiles.
 To plot the CDF for a data distribution, we can use the `geom_step()` function in [ggplot2]{.monospace}.
 
 @.
@@ -110,7 +147,7 @@ The following functions in R are useful for computing the summary statistics of 
 Because there is a spread in the time measurements in Newcomb's dataset, the measured time should be reported as a mean value with error bars.
 The error bars are typically found by calculating a confidence interval.
 A typical choice is a 95% confidence interval, which can be estimated using computational simulations that *resample* the dataset.
-To perform our statistical resampling, we will use the [tidyverse]{.monospace}-inspired [[infer]{.monospace} package][r-infer-github], which will help us to compute confidence intervals and perform hypothesis tests.
+To perform our statistical resampling, we will use the [tidyverse]{.monospace}-inspired [`r icon_link`[infer]{.monospace} package][r-infer-github], which will help us to compute confidence intervals and perform hypothesis tests.
 
 To compute the confidence interval, we will need to generate the so-called *bootstrap distribution*.
 We obtain the bootstrap simulation using the following code:
@@ -133,10 +170,10 @@ newcomb_bootstrap %>%
 What the bootstrap has done is sample *with replacement* from the dataset distribution.
 The basic idea is that, if the underlying sample is representative, then we can sample directly from it *as if it were the true population*.
 The number of samples we pull is equal to the number of observations in the dataset.
-After we resample the data, we complete the procedure by calculating the [mean]{.monospace} of the simulated sample (or [median]{.monospace}, [sd]{.monospace}, or some other parameter), after which we then repeat the process multiple times until we end up with a distribution of means.
+After we resample the data, we complete the procedure by calculating the [mean]{.monospace} of the simulated sample (or [median]{.monospace}, [sd]{.monospace}, or some other parameter), after which we then repeat the process multiple times until we end up with a distribution of these computed means.
 We can then use the bootstrap sample to determine the confidence interval for the sample statistic of interest.
 
-The 95% confidence interval is defined as the fraction of the data in the bootstrap distribution that lies between the 2.5th and 97.5th percentiles, which we can compute as follows:
+The [infer]{.monospace} package provides a convenience function `get_confidence_interval()` that makes it very easy for us to find the 95% confidence interval from the bootstrap distribution,
 
 ```r
 newcomb_ci <- newcomb_bootstrap %>%
@@ -153,7 +190,7 @@ newcomb_bootstrap %>%
 ```
 
 @.
-    Using the above code, compute the 95% confidence interval for the unfiltered and filtered dataset using the bootstrap method and visualize both of them.
+    Using the above code, compute the 95% confidence interval for **both** the unfiltered and filtered dataset using the bootstrap method and visualize both of them.
     Make sure that you also print out the values of the confidence interval.
     How does the confidence interval change when you exclude the outliers (the filtered dataset)?
     
@@ -163,7 +200,9 @@ Of course, in order to run a hypothesis test we need some sort of hypothesis to 
 We also need to select a significance level $\alpha$, which serves as a kind of evidence threshold that we use when determining whether or not we can reject the null hypothesis.
 A common choice for $\alpha$ is 0.05, which is the value that we will use.
 
-Subsequent work on the speed of light has determined that, given the conditions of Newcomb's setup, that this experiment should yield a "true" mean value of 33.02.
+Before we continue, we need to know what the null value for our hypothesis test will be.
+Subsequent work on measuring the speed of light has determined that, given the conditions of Newcomb's setup, that this experiment should yield a "true" mean value of 33.02.
+This will serve as our null value.
 With this value in hand, we can formalize the question of whether or not the gap separating our dataset's distribution could have been generated by chance alone.
 
 @.
@@ -202,14 +241,13 @@ If the computed p-value is less than 0.05, our significance level, then we rejec
     Use the [infer]{.monospace} package to run the two-sided hypothesis test with $\alpha = 0.05$ between the ideal value of 33.02 and unfiltered and filtered datasets.
     Can we reject the null hypothesis for either version (filtered or unfiltered) of the dataset?
 
-## Additional questions
+## Additional exercises
 
-:::::{.additional-questions}
-*   From your analysis, does Newcomb's dataset seem to agree with the "true" mean value of 33.02?
+@.
+    From your analysis, does Newcomb's dataset seem to agree with the "true" mean value of 33.02?
     Or is it inconsistent?
     Make reference to your confidence intervals of both the unfiltered and filtered datasets when answering these questions as well as your two-sided hypothesis test.
     Based on all this, how likely is it that a systematic bias exists within Newcomb's dataset?
-:::::
 
 ## How to submit
 
@@ -221,6 +259,22 @@ Your lab will be graded for credit **after** you've completed both steps!
 
 2.  Knit your R Markdown document to the PDF format, export (download) the PDF file from RStudio Server, and then upload it to *`r lab_name`* posting on Blackboard.
 
+## Cheatsheets
+
+You are encouraged to review and keep the following cheatsheets handy while working on this lab:
+
+*   [data import/tidyr cheatsheet][data-import-cheatsheet]
+
+*   [dplyr cheatsheet][dplyr-cheatsheet]
+
+*   [ggplot2 cheatsheet][ggplot2-cheatsheet]
+
+*   [RStudio cheatsheet][rstudio-cheatsheet]
+
+*   [R Markdown cheatsheet][rmarkdown-cheatsheet]
+
+*   [R Markdown reference][rmarkdown-reference]
+
 ## Credits
 
 This lab is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa-4].
@@ -228,5 +282,11 @@ Exercises and instructions written by James Glasbrenner for CDS-102.
 
 ## References
 
-[cc-by-sa-4]:     http://creativecommons.org/licenses/by-sa/4.0/
-[r-infer-github]: https://infer.netlify.com/
+[cc-by-sa-4]:             http://creativecommons.org/licenses/by-sa/4.0/
+[r-infer-github]:         https://infer.netlify.com/
+[dplyr-cheatsheet]:       https://github.com/rstudio/cheatsheets/raw/master/data-transformation.pdf
+[ggplot2-cheatsheet]:     https://www.rstudio.com/wp-content/uploads/2016/11/ggplot2-cheatsheet-2.1.pdf
+[rstudio-cheatsheet]:     https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf
+[rmarkdown-reference]:    https://www.rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf
+[rmarkdown-cheatsheet]:   https://github.com/rstudio/cheatsheets/raw/master/rmarkdown-2.0.pdf
+[data-import-cheatsheet]: https://github.com/rstudio/cheatsheets/raw/master/data-import.pdf 


### PR DESCRIPTION
An instructions preamble has been added to the beginning of Lab 8, and the "About the dataset" section was revised to better match the way datasets are introduced in the CDS 101 homeworks. The lab instructions in general have been edited and revised to improve clarity. Other minor changes include,

- Hint-like parentheticals were moved into callout boxes
- Formal references now have proper in-text citations via BibTeX
- The "Additional questions" section has been renamed "Additional exercises"
- A list of relevant cheatsheets is linked at the end of the lab instructions