### PR TITLE
content(labs): basketball and hot hands

### DIFF
--- a/content/Labs/lab07-basketball-and-hot-hands.Rmd
+++ b/content/Labs/lab07-basketball-and-hot-hands.Rmd
@@ -55,16 +55,16 @@ The table below provides descriptions of the dataset's 6 variables,
 
 ## Defining a shooting streak
 
-If you inspect the [shot]{.monospace} column, you'll quickly find that looking at a string of [H]{.monospace}'s and [M]{.monospace}'s makes it be difficult to gauge whether or not it seems like Kobe was shooting with a hot hand.
-To make any progress, we will need to define what we mean when we say a player has a hot hand. 
-For the purposes of our investigation, we will base our hot hand definition on the belief that hot hand shooters tend to go on shooting streaks, where the length of a shooting streak is defined as the *number of consecutive baskets a player makes until a miss occurs*.
+If you inspect the [shot]{.monospace} column, you'll quickly find that inspecting a string of [H]{.monospace}'s and [M]{.monospace}'s by eye makes it be difficult to gauge whether or not it seems like Kobe was shooting with a hot hand.
+To make any progress we will need to define what we mean when we say a player has a hot hand. 
+For the purposes of our investigation, we will base our hot hand definition on the belief that hot hand shooters tend to go on shooting streaks, where the length of a shooting streak is defined as the _number of consecutive baskets a player makes until a miss occurs_.
 
-For example, in Game 1 Kobe had the following sequence of hits and misses from his nine shot attempts in the first quarter:
+For example, in Game 1 Kobe Bryant had the following sequence of hits and misses from his nine shot attempts in the first quarter:
 
     H M | M | H H M | M | M | M
 
 You can verify this by viewing the first 8 rows of the dataset using `View()`.
-Within these nine shot attempts, there are six streaks, which are separated by a [|]{.monospace} above.
+Within these nine shot attempts there are six streaks, which are separated by a [|]{.monospace} above.
 The lengths of each streak are one, zero, two, zero, zero, zero (in order of occurrence).
 
 @.
@@ -99,21 +99,21 @@ This function has been loaded automatically for you in your R Markdown report fi
 We've shown that Kobe had some long shooting streaks, but are they long enough to support the belief that he had a hot hand?
 What can we compare them to?
 
-To answer these questions, let's return to the idea of _independence_.
+To address these questions we will need to make use of the concept of _independence_.
 Two processes are independent if the outcome of one process doesn't affect the outcome of the second.
-If each shot that a player takes is an independent process, then that means that making or missing your first shot **will not** affect the probability that you will make or miss your second shot.
-
+So if each shot that a player takes is an independent process, then that means that making or missing your first shot **will not** affect the probability that you will make or miss your second shot.
 Conversely, a shooter with a hot hand will have shots that are **not** independent of one another.
 Specifically, if the shooter makes his first shot, the hot hand model says he will have a _higher_ probability of making his second shot.
 
 Let's suppose for a moment that the hot hand model is valid for Kobe.
-During his career, the percentage of time Kobe makes a basket (i.e. his shooting percentage) is about 45%, or in probability notation,
+During his career, the percentage of times that Kobe makes a basket (i.e. his shooting percentage) is about 45%, or in probability notation,
 $$P(\text{shot 1 = H}) = 0.45$$
 If he makes the first shot and has a hot hand (remember, this would mean that shots are **not** independent), then the probability that he makes his second shot would go up to, let's say, 60%,
 $$P(\text{shot 2 = H} \, | \, \text{shot 1 = H}) = 0.60$$
 As a result of these increased probabilites, you'd expect Kobe to have longer streaks.
+
 Compare this to the skeptical perspective where Kobe does *not* have a hot hand, where each shot is independent of the next.
-If he hit his first shot, the probability that he makes the second is still 0.45.
+If he hit his first shot, the probability that he makes the second would still be 0.45,
 $$P(\text{shot 2 = H} \, | \, \text{shot 1 = H}) = 0.45$$
 In other words, making the first shot did nothing to affect the probability that he'd make his second shot.
 If Kobe's shots are independent, then he'd have the same probability of hitting every shot regardless of his past shots: 45%.
@@ -125,23 +125,18 @@ We can compare his streak lengths to someone without a hot hand: an independent 
 
 While we don't have any data from a shooter we know to have independent shots, this sort of data is easy to simulate in R using a package called [infer]{.monospace}.
 In a simulation, you set the ground rules of a random process and then the computer uses random numbers to generate an outcome that adheres to those rules.
-As a simple example, let's simulate flipping a fair coin, which has a 50% chance of coming up heads and a 50% chance of coming up tails.
-Our [infer]{.monospace} template for flipping a coin is as follows,
+As a simple example let's simulate 100 flips of a fair coin, which has a 50% chance of coming up heads and a 50% chance of coming up tails.
+Our [infer]{.monospace} template for this simulation is as follows,
 
 ```r
 probability_heads <- 0.5
-number_of_reps <- 50
 
-tibble(outcome = combine("heads", "tails")) %>%
+tibble(outcome = rep(combine("heads", "tails"), each = 50)) %>%
   specify(outcome ~ NULL, success = "heads") %>%
   hypothesize(null = "point", p = probability_heads) %>%
-  generate(reps = number_of_reps, type = "simulate") %>%
-  calculate(stat = "count") %>%
-  summarize(
-    num_coin_flips = 2 * number_of_reps,
-    num_heads = sum(stat),
-    num_tails = num_coin_flips - num_heads
-  )
+  generate(reps = 1, type = "simulate") %>%
+  ungroup() %>%
+  count(outcome)
 ```
 
 @sim-fair-coin.
@@ -160,9 +155,9 @@ How could we do this?
 @.
     Copy and paste the code block from **Exercise @sim-fair-coin** and adjust the value for [probability_heads]{.monospace} from [0.5]{.monospace} to [0.2]{.monospace}, which is how we tell R that we want the probability of flipping heads to be 20%.
     Run the code block.
-    In your simulation of flipping the unfair coin 100 times, how many flips came up heads?
+    In your simulation of 100 flips of the unfair coin, how many flips came up heads?
     
-    If you wanted the probability of **flipping tails** to be 40%, what should you set [probability_heads]{.monospace} equal to?
+    If you wanted the probability of **flipping tails** to be 45%, what should you set [probability_heads]{.monospace} equal to?
 
 ## Simulating the Independent Shooter
 
@@ -180,29 +175,31 @@ sim_basket <- kobe_basket %>%
   transmute(shot = as.character(shot))
 ```
 
-To make a valid comparison between Kobe and our simulated independent shooter, we need to align both their shooting percentage and the number of attempted shots.
+Notice here that the dataset [kobe_basket]{.monospace} is being piped into `specify()`.
+This does two things, (1) it will ensure that our shot outcomes will be labeled as either [H]{.monospace} or [M]{.monospace}, and (2) it will ensure that our simulated independent shooter will take 133 shots, the same number of shots that Kobe Bryant takes in this dataset.
+
 
 @.
+    To make a valid comparison between Kobe and our simulated independent shooter, we need to align their shooting percentages.
     What change needs to be made to the code template so that it reflects a shooting percentage of 45%?
     Make this adjustment, then run a simulation to sample 133 shots.
-    Assign the output of this simulation to [sim_basket]{.monospace}.
+    This will assign the output of this simulation to [sim_basket]{.monospace}.
 
 With the results of the simulation saved as [sim_basket]{.monospace}, we have the data necessary to compare Kobe to our independent shooter.
-
-Both data sets represent the results of 133 shot attempts, each with the same shooting percentage of 45%.
+Both datasets represent the results of 133 shot attempts, each with the same shooting percentage of 45%.
 We know that our simulated data is from a shooter that has independent shots.
 That is, we know the simulated shooter does not have a hot hand.
 
 ## Additional exercises
 
 @.
-    Using `calc_streak()`, compute the streak lengths of [sim_basket]{.monospace}, and assign the results to a variable named [sim_streak]{.monospace}.
+    Using `calc_streak()`, compute the streak lengths for the simulated independent shooter saved to [sim_basket]{.monospace}.
+    Assign the results of `calc_streak()` to a variable named [sim_streak]{.monospace}.
 
 @.
-    Describe the distribution of streak lengths.
-    What is the typical streak length for this simulated independent shooter with a 45% shooting percentage?
+    Visualize the distribution of simulated streak lengths and discuss it.
+    Based on your results, what is the typical streak length for this simulated independent shooter with a 45% shooting percentage?
     How long is the player's longest streak of baskets in 133 shots?
-    Make sure to include a plot in your answer.
 
 @.
     If you were to run the simulation of the independent shooter a second time, how would you expect its streak distribution to compare to the distribution from the question above?

--- a/content/Labs/lab07-basketball-and-hot-hands.Rmd
+++ b/content/Labs/lab07-basketball-and-hot-hands.Rmd
@@ -28,25 +28,21 @@ Then, when you're ready to submit, follow the directions in the [`r icon_link`Ho
 
 ## The Hot Hand
 
-Basketball players who make several baskets in succession are described as having a *hot hand*.
+Basketball players who make several baskets in succession are described as having a _hot hand_.
 Fans and players have long believed in the hot hand phenomenon, which refutes the assumption that each shot is independent of the next.
 However, [`r icon_link`a 1985 paper][gilovich-paper] by Gilovich, Vallone, and Tversky collected evidence that contradicted this belief and showed that successive shots are independent events.
-This paper started a great controversy that continues to this day, as you can see by Googling *hot hand basketball*.
+This paper started a great controversy that continues to this day, as you can see by Googling _hot hand basketball_.
 
 We do not expect to resolve this controversy today.
-However, in this lab we'll apply one approach to answering questions like this.
-The goals for this lab are to (1) think about the effects of independent and dependent events, (2) learn how to simulate shooting streaks in R, and (3) to compare a simulation to actual data in order to determine if the hot hand phenomenon appears to be real.
+However, we'll apply one approach to answering questions like this, which will allow us to (1) think about the effects of independent and dependent events, (2) learn how to simulate shooting streaks in R, and (3) to compare a simulation to actual data in order to determine if the hot hand phenomenon appears to be real.
 
-## About the dataset  {#about-the-dataset}
+## About the dataset
 
 Our investigation will focus on the performance of one player: [`r icon_link`Kobe Bryant][kobe-bryant-wiki] of the Los Angeles Lakers.
 His performance against the Orlando Magic in the [`r icon_link`2009 NBA Finals][2009-nba-finals-wiki] earned him the title *Most Valuable Player* and many spectators commented on how he appeared to show a hot hand.
+Accordingly, our dataset is taken from the five games the Los Angeles Lakers played against the Orlando Magic in the 2009 NBA finals.
 
-### Data contents
-
-Data from the five games the Los Angeles Lakers played against the Orlando Magic in the 2009 NBA finals.
-This dataset contains 133 observations and 6 variables, where every row records a shot taken by Kobe Bryant.
-The [shot]{.monospace} variable in this dataset indicates whether the shot was a hit ([H]{.monospace}) or a miss ([M]{.monospace}).
+The table below provides descriptions of the dataset's 6 variables,
 
 | Variable                  | Description                                          |
 | -------------             | ---------------------------------------------------- |
@@ -59,57 +55,61 @@ The [shot]{.monospace} variable in this dataset indicates whether the shot was a
 
 ## Defining a shooting streak
 
-Just looking at the string of hits and misses, it can be difficult to gauge whether or not it seems like Kobe was shooting with a hot hand.
-One way we can approach this is by considering the belief that hot hand shooters tend to go on shooting streaks.
-For this lab, we define the length of a shooting streak to be the *number of consecutive baskets made until a miss occurs*.
+If you inspect the [shot]{.monospace} column, you'll quickly find that looking at a string of [H]{.monospace}'s and [M]{.monospace}'s makes it be difficult to gauge whether or not it seems like Kobe was shooting with a hot hand.
+To make any progress, we will need to define what we mean when we say a player has a hot hand. 
+For the purposes of our investigation, we will base our hot hand definition on the belief that hot hand shooters tend to go on shooting streaks, where the length of a shooting streak is defined as the *number of consecutive baskets a player makes until a miss occurs*.
 
 For example, in Game 1 Kobe had the following sequence of hits and misses from his nine shot attempts in the first quarter:
 
     H M | M | H H M | M | M | M
 
-You can verify this by viewing the first 8 rows of the data in the data viewer.
-
-Within the nine shot attempts, there are six streaks, which are separated by a "|" above.
-Their lengths are one, zero, two, zero, zero, zero (in order of occurrence).
+You can verify this by viewing the first 8 rows of the dataset using `View()`.
+Within these nine shot attempts, there are six streaks, which are separated by a [|]{.monospace} above.
+The lengths of each streak are one, zero, two, zero, zero, zero (in order of occurrence).
 
 @.
     What does a streak length of 1 mean, i.e. how many hits and misses are in a streak of 1?
     What about a streak length of 0?
 
-Counting streak lengths manually for all 133 shots would get tedious, so we'll use the custom function `calc_streak()` to calculate them, and store the results in a tibble called [kobe_streak]{.monospace} as the [length]{.monospace} variable.
-
-```r
-kobe_streak <- calc_streak(kobe_basket$shot)
-```
-
-We can then take a look at the distribution of these streak lengths.
-
-```r
-ggplot(data = kobe_streak) +
-  geom_bar(mapping = aes(x = length))
-```
+Counting streak lengths manually for all 133 of Kobe's shots would get tedious, so we'll use the function `calc_streak()` to calculate them.
+This function has been loaded automatically for you in your R Markdown report file.
 
 @.
-    Describe the distribution of Kobe's streak lengths from the 2009 NBA finals. 
-    What was his typical streak length? How long was his longest streak of baskets?
-    Make sure to include the accompanying plot in your answer.
+    Run the following code to calculate the length of Kobe's shooting streaks,
 
-## Compared to What?
+    ```r
+    kobe_streak <- calc_streak(kobe_basket)
+    ```
+
+    then visualize the distribution of the streak lengths.
+
+    ```r
+    ggplot(kobe_streak) +
+      geom_bar(
+        mapping = aes(x = length)
+      )
+    ```
+
+    Describe the distribution of Kobe's streak lengths from the 2009 NBA finals. 
+    What was his typical streak length?
+    How long was his longest streak of baskets?
+
+## Compared to what?
 
 We've shown that Kobe had some long shooting streaks, but are they long enough to support the belief that he had a hot hand?
 What can we compare them to?
 
-To answer these questions, let's return to the idea of *independence*.
+To answer these questions, let's return to the idea of _independence_.
 Two processes are independent if the outcome of one process doesn't affect the outcome of the second.
-If each shot that a player takes is an independent process, having made or missed your first shot will not affect the probability that you will make or miss your second shot.
+If each shot that a player takes is an independent process, then that means that making or missing your first shot **will not** affect the probability that you will make or miss your second shot.
 
-A shooter with a hot hand will have shots that are *not* independent of one another.
-Specifically, if the shooter makes his first shot, the hot hand model says he will have a *higher* probability of making his second shot.
+Conversely, a shooter with a hot hand will have shots that are **not** independent of one another.
+Specifically, if the shooter makes his first shot, the hot hand model says he will have a _higher_ probability of making his second shot.
 
 Let's suppose for a moment that the hot hand model is valid for Kobe.
 During his career, the percentage of time Kobe makes a basket (i.e. his shooting percentage) is about 45%, or in probability notation,
 $$P(\text{shot 1 = H}) = 0.45$$
-If he makes the first shot and has a hot hand (*not* independent shots), then the probability that he makes his second shot would go up to, let's say, 60%,
+If he makes the first shot and has a hot hand (remember, this would mean that shots are **not** independent), then the probability that he makes his second shot would go up to, let's say, 60%,
 $$P(\text{shot 2 = H} \, | \, \text{shot 1 = H}) = 0.60$$
 As a result of these increased probabilites, you'd expect Kobe to have longer streaks.
 Compare this to the skeptical perspective where Kobe does *not* have a hot hand, where each shot is independent of the next.
@@ -123,63 +123,46 @@ We can compare his streak lengths to someone without a hot hand: an independent 
 
 ## Simulations in R
 
-While we don't have any data from a shooter we know to have independent shots, that sort of data is very easy to simulate in R.
+While we don't have any data from a shooter we know to have independent shots, this sort of data is easy to simulate in R using a package called [infer]{.monospace}.
 In a simulation, you set the ground rules of a random process and then the computer uses random numbers to generate an outcome that adheres to those rules.
-As a simple example, you can simulate flipping a fair coin with the following.
+As a simple example, let's simulate flipping a fair coin, which has a 50% chance of coming up heads and a 50% chance of coming up tails.
+Our [infer]{.monospace} template for flipping a coin is as follows,
 
 ```r
-coin_outcomes <- c("heads", "tails")
-sample(coin_outcomes, size = 1, replace = TRUE)
+probability_heads <- 0.5
+number_of_reps <- 50
+
+tibble(outcome = combine("heads", "tails")) %>%
+  specify(outcome ~ NULL, success = "heads") %>%
+  hypothesize(null = "point", p = probability_heads) %>%
+  generate(reps = number_of_reps, type = "simulate") %>%
+  calculate(stat = "count") %>%
+  summarize(
+    num_coin_flips = 2 * number_of_reps,
+    num_heads = sum(stat),
+    num_tails = num_coin_flips - num_heads
+  )
 ```
 
-The vector [coin_outcomes]{.monospace} can be thought of as a hat with two slips of paper in it: one slip says [heads]{.monospace} and the other says [tails]{.monospace}.
-The function `sample()` draws one slip from the hat and tells us if it was a head or a tail.
+@sim-fair-coin.
+    Copy and paste all of the above template code into a single code block within your R Markdown notebook and run it.
+    This will simulate the flipping of a fair coin 100 times.
+    From inspecting the results table and seeing the number of times you flip a heads versus tails, does this seem to behave like a fair coin?
+    Why or why not?
+    
+    Next, re-run the same code block a couple more times and watch what happens to the results table.
+    Does it stay the same or does it change?
+    If it changes, why would your result be different each time you run the simulation?
 
-Run the second command listed above several times in the *Console* pane.
-Just like when flipping a coin, sometimes you'll get a heads, sometimes you'll get a tails, but in the long run, you'd expect to get roughly equal numbers of each.
-
-If you wanted to simulate flipping a fair coin 100 times, you could either run the function 100 times or, more simply, adjust the [size]{.monospace} argument, which governs how many samples to draw (the [replace = TRUE]{.monospace} argument indicates we put the slip of paper back in the hat before drawing again).
-Assign the resulting vector of heads and tails to a new variable called [sim_fair_coin]{.monospace}.
-
-```r
-sim_fair_coin <- sample(coin_outcomes, size = 100, replace = TRUE)
-```
-
-To view the results of this simulation, type the name of the object and then use [table]{.monospace} to count up the number of heads and tails.
-
-```r
-sim_fair_coin
-table(sim_fair_coin)
-```
-
-Since there are only two elements in [coin_outcomes]{.monospace}, the probability that we "flip" a coin and it lands heads is 0.5.
-Say we're trying to simulate an unfair coin that we know only lands heads 20% of the time.
-We can adjust for this by adding an argument called [prob]{.monospace}, which provides a vector of two probability weights.
-
-```r
-sim_unfair_coin <- sample(coin_outcomes, size = 100, replace = TRUE, 
-                          prob = c(0.2, 0.8))
-```
-
-[prob = c(0.2, 0.8)]{.monospace} indicates that for the two elements in the [outcomes]{.monospace} vector, we want to select the first one, [heads]{.monospace}, with probability 0.2 and the second one, [tails]{.monospace} with probability 0.8.
-Another way of thinking about this is to think of the outcome space as a bag of 10 chips, where 2 chips are labeled "head" and 8 chips "tail".
-Therefore at each draw, the probability of drawing a chip that says "head"" is 20%, and "tail" is 80%.
+Now, imagine that we wanted to simulate an _unfair_ coin that only lands on heads 20% of the time.
+How could we do this?
 
 @.
+    Copy and paste the code block from **Exercise @sim-fair-coin** and adjust the value for [probability_heads]{.monospace} from [0.5]{.monospace} to [0.2]{.monospace}, which is how we tell R that we want the probability of flipping heads to be 20%.
+    Run the code block.
     In your simulation of flipping the unfair coin 100 times, how many flips came up heads?
-    Include the code for sampling the unfair coin in your response.
-    Since the markdown file will run the code, and generate a new sample each time you *Knit* it, you should also "set a seed" **before** you sample.
-    Read more about setting a seed below.
-
-In a sense, we've shrunken the size of the slip of paper that says "heads", making it less likely to be drawn and we've increased the size of the slip of paper saying "tails", making it more likely to be drawn.
-When we simulated the fair coin, both slips of paper were the same size.
-This happens by default if you don't provide a [prob]{.monospace} argument; all elements in the [outcomes]{.monospace} vector have an equal probability of being drawn.
-
-If you want to learn more about `sample()` or any other function, recall that you can always check out its help file.
-
-```r
-?sample
-```
+    
+    If you wanted the probability of **flipping tails** to be 40%, what should you set [probability_heads]{.monospace} equal to?
 
 ## Simulating the Independent Shooter
 
@@ -187,19 +170,22 @@ Simulating a basketball player who has independent shots uses the same mechanism
 To simulate a single shot from an independent shooter with a shooting percentage of 50% we type,
 
 ```r
-shot_outcomes <- c("H", "M")
-sim_basket <- sample(shot_outcomes, size = 1, replace = TRUE)
+probability_hit <- 0.5
+
+sim_basket <- kobe_basket %>%
+  specify(shot ~ NULL, success = "H") %>%
+  hypothesize(null = "point", p = probability_hit) %>%
+  generate(reps = 1, type = "simulate") %>%
+  ungroup() %>%
+  transmute(shot = as.character(shot))
 ```
 
 To make a valid comparison between Kobe and our simulated independent shooter, we need to align both their shooting percentage and the number of attempted shots.
 
 @.
-    What change needs to be made to the `sample()` function so that it reflects a shooting percentage of 45%?
+    What change needs to be made to the code template so that it reflects a shooting percentage of 45%?
     Make this adjustment, then run a simulation to sample 133 shots.
-    Assign the output of this simulation to a new object called [sim_basket]{.monospace}.
-
-Note that we've named the new vector [sim_basket]{.monospace}, the same name that we gave to the previous vector reflecting a shooting percentage of 50%.
-In this situation, R overwrites the old object with the new one, so always make sure that you don't need the information in an old vector before reassigning its name.
+    Assign the output of this simulation to [sim_basket]{.monospace}.
 
 With the results of the simulation saved as [sim_basket]{.monospace}, we have the data necessary to compare Kobe to our independent shooter.
 
@@ -210,10 +196,11 @@ That is, we know the simulated shooter does not have a hot hand.
 ## Additional exercises
 
 @.
-    Using `calc_streak()`, compute the streak lengths of [sim_basket]{.monospace}, and assign the results to a variable named [sim_streak]{.monospace}. Note that since the [sim_streak]{.monospace} object is just a vector and not a variable in a tibble, we don’t need to select it using the dollar sign symbol [\$]{.monospace} like we did earlier when we calculated the streak lengths for Kobe’s shots.
+    Using `calc_streak()`, compute the streak lengths of [sim_basket]{.monospace}, and assign the results to a variable named [sim_streak]{.monospace}.
 
 @.
-    Describe the distribution of streak lengths. What is the typical streak length for this simulated independent shooter with a 45% shooting percentage?
+    Describe the distribution of streak lengths.
+    What is the typical streak length for this simulated independent shooter with a 45% shooting percentage?
     How long is the player's longest streak of baskets in 133 shots?
     Make sure to include a plot in your answer.
 

--- a/content/Labs/lab07-basketball-and-hot-hands.Rmd
+++ b/content/Labs/lab07-basketball-and-hot-hands.Rmd
@@ -6,7 +6,7 @@ Tags: lab
 Slug: lab-07-basketball-hot-hands
 Summary: Use randomized simulations to determine whether or not basketball players can have a "hot hand"
 Show_summary: true
-Show_link: false
+Show_link: true
 
 ```{r setup, include = FALSE}
 suppressPackageStartupMessages(library(tidyverse))
@@ -18,3 +18,259 @@ icon_link_bullet <- '<i class="fas fa-link" data-fa-transform="grow-2"></i>&nbsp
 lab_name <- "Lab 7"
 starter_file <- "lab07.Rmd"
 ```
+
+## Instructions
+
+Obtain the GitHub repository you will use to complete the lab, which contains a starter file named [`r starter_file`]{.monospace}.
+This lab shows you how we can use randomized simulations to gain insight into whether or not basketball players can have a "hot hand".
+Carefully read the lab instructions and complete the exercises using the provided spaces within your starter file [`r starter_file`]{.monospace}.
+Then, when you're ready to submit, follow the directions in the [`r icon_link`How to submit](#how-to-submit) section below.
+
+## The Hot Hand
+
+Basketball players who make several baskets in succession are described as having a *hot hand*.
+Fans and players have long believed in the hot hand phenomenon, which refutes the assumption that each shot is independent of the next.
+However, [`r icon_link`a 1985 paper][gilovich-paper] by Gilovich, Vallone, and Tversky collected evidence that contradicted this belief and showed that successive shots are independent events.
+This paper started a great controversy that continues to this day, as you can see by Googling *hot hand basketball*.
+
+We do not expect to resolve this controversy today.
+However, in this lab we'll apply one approach to answering questions like this.
+The goals for this lab are to (1) think about the effects of independent and dependent events, (2) learn how to simulate shooting streaks in R, and (3) to compare a simulation to actual data in order to determine if the hot hand phenomenon appears to be real.
+
+## About the dataset  {#about-the-dataset}
+
+Our investigation will focus on the performance of one player: [`r icon_link`Kobe Bryant][kobe-bryant-wiki] of the Los Angeles Lakers.
+His performance against the Orlando Magic in the [`r icon_link`2009 NBA Finals][2009-nba-finals-wiki] earned him the title *Most Valuable Player* and many spectators commented on how he appeared to show a hot hand.
+
+### Data contents
+
+Data from the five games the Los Angeles Lakers played against the Orlando Magic in the 2009 NBA finals.
+This dataset contains 133 observations and 6 variables, where every row records a shot taken by Kobe Bryant.
+The [shot]{.monospace} variable in this dataset indicates whether the shot was a hit ([H]{.monospace}) or a miss ([M]{.monospace}).
+
+| Variable                  | Description                                          |
+| -------------             | ---------------------------------------------------- |
+| [vs]{.monospace}          | ORL if the Los Angeles Lakers played against Orlando |
+| [game]{.monospace}        | game in the 2009 NBA finals                          |
+| [quarter]{.monospace}     | quarter in the game, OT stands for overtime          |
+| [time]{.monospace}        | time of game in seconds at which Kobe took a shot    |
+| [description]{.monospace} | description of the shot                              |
+| [shot]{.monospace}        | H if the shot was a hit, M if the shot was a miss    |
+
+## Defining a shooting streak
+
+Just looking at the string of hits and misses, it can be difficult to gauge whether or not it seems like Kobe was shooting with a hot hand.
+One way we can approach this is by considering the belief that hot hand shooters tend to go on shooting streaks.
+For this lab, we define the length of a shooting streak to be the *number of consecutive baskets made until a miss occurs*.
+
+For example, in Game 1 Kobe had the following sequence of hits and misses from his nine shot attempts in the first quarter:
+
+    H M | M | H H M | M | M | M
+
+You can verify this by viewing the first 8 rows of the data in the data viewer.
+
+Within the nine shot attempts, there are six streaks, which are separated by a "|" above.
+Their lengths are one, zero, two, zero, zero, zero (in order of occurrence).
+
+@.
+    What does a streak length of 1 mean, i.e. how many hits and misses are in a streak of 1?
+    What about a streak length of 0?
+
+Counting streak lengths manually for all 133 shots would get tedious, so we'll use the custom function `calc_streak()` to calculate them, and store the results in a tibble called [kobe_streak]{.monospace} as the [length]{.monospace} variable.
+
+```r
+kobe_streak <- calc_streak(kobe_basket$shot)
+```
+
+We can then take a look at the distribution of these streak lengths.
+
+```r
+ggplot(data = kobe_streak) +
+  geom_bar(mapping = aes(x = length))
+```
+
+@.
+    Describe the distribution of Kobe's streak lengths from the 2009 NBA finals. 
+    What was his typical streak length? How long was his longest streak of baskets?
+    Make sure to include the accompanying plot in your answer.
+
+## Compared to What?
+
+We've shown that Kobe had some long shooting streaks, but are they long enough to support the belief that he had a hot hand?
+What can we compare them to?
+
+To answer these questions, let's return to the idea of *independence*.
+Two processes are independent if the outcome of one process doesn't affect the outcome of the second.
+If each shot that a player takes is an independent process, having made or missed your first shot will not affect the probability that you will make or miss your second shot.
+
+A shooter with a hot hand will have shots that are *not* independent of one another.
+Specifically, if the shooter makes his first shot, the hot hand model says he will have a *higher* probability of making his second shot.
+
+Let's suppose for a moment that the hot hand model is valid for Kobe.
+During his career, the percentage of time Kobe makes a basket (i.e. his shooting percentage) is about 45%, or in probability notation,
+$$P(\text{shot 1 = H}) = 0.45$$
+If he makes the first shot and has a hot hand (*not* independent shots), then the probability that he makes his second shot would go up to, let's say, 60%,
+$$P(\text{shot 2 = H} \, | \, \text{shot 1 = H}) = 0.60$$
+As a result of these increased probabilites, you'd expect Kobe to have longer streaks.
+Compare this to the skeptical perspective where Kobe does *not* have a hot hand, where each shot is independent of the next.
+If he hit his first shot, the probability that he makes the second is still 0.45.
+$$P(\text{shot 2 = H} \, | \, \text{shot 1 = H}) = 0.45$$
+In other words, making the first shot did nothing to affect the probability that he'd make his second shot.
+If Kobe's shots are independent, then he'd have the same probability of hitting every shot regardless of his past shots: 45%.
+
+Now that we've phrased the situation in terms of independent shots, let's return to the question: how do we tell if Kobe's shooting streaks are long enough to indicate that he has a hot hand?
+We can compare his streak lengths to someone without a hot hand: an independent shooter.
+
+## Simulations in R
+
+While we don't have any data from a shooter we know to have independent shots, that sort of data is very easy to simulate in R.
+In a simulation, you set the ground rules of a random process and then the computer uses random numbers to generate an outcome that adheres to those rules.
+As a simple example, you can simulate flipping a fair coin with the following.
+
+```r
+coin_outcomes <- c("heads", "tails")
+sample(coin_outcomes, size = 1, replace = TRUE)
+```
+
+The vector [coin_outcomes]{.monospace} can be thought of as a hat with two slips of paper in it: one slip says [heads]{.monospace} and the other says [tails]{.monospace}.
+The function `sample()` draws one slip from the hat and tells us if it was a head or a tail.
+
+Run the second command listed above several times in the *Console* pane.
+Just like when flipping a coin, sometimes you'll get a heads, sometimes you'll get a tails, but in the long run, you'd expect to get roughly equal numbers of each.
+
+If you wanted to simulate flipping a fair coin 100 times, you could either run the function 100 times or, more simply, adjust the [size]{.monospace} argument, which governs how many samples to draw (the [replace = TRUE]{.monospace} argument indicates we put the slip of paper back in the hat before drawing again).
+Assign the resulting vector of heads and tails to a new variable called [sim_fair_coin]{.monospace}.
+
+```r
+sim_fair_coin <- sample(coin_outcomes, size = 100, replace = TRUE)
+```
+
+To view the results of this simulation, type the name of the object and then use [table]{.monospace} to count up the number of heads and tails.
+
+```r
+sim_fair_coin
+table(sim_fair_coin)
+```
+
+Since there are only two elements in [coin_outcomes]{.monospace}, the probability that we "flip" a coin and it lands heads is 0.5.
+Say we're trying to simulate an unfair coin that we know only lands heads 20% of the time.
+We can adjust for this by adding an argument called [prob]{.monospace}, which provides a vector of two probability weights.
+
+```r
+sim_unfair_coin <- sample(coin_outcomes, size = 100, replace = TRUE, 
+                          prob = c(0.2, 0.8))
+```
+
+[prob = c(0.2, 0.8)]{.monospace} indicates that for the two elements in the [outcomes]{.monospace} vector, we want to select the first one, [heads]{.monospace}, with probability 0.2 and the second one, [tails]{.monospace} with probability 0.8.
+Another way of thinking about this is to think of the outcome space as a bag of 10 chips, where 2 chips are labeled "head" and 8 chips "tail".
+Therefore at each draw, the probability of drawing a chip that says "head"" is 20%, and "tail" is 80%.
+
+@.
+    In your simulation of flipping the unfair coin 100 times, how many flips came up heads?
+    Include the code for sampling the unfair coin in your response.
+    Since the markdown file will run the code, and generate a new sample each time you *Knit* it, you should also "set a seed" **before** you sample.
+    Read more about setting a seed below.
+
+In a sense, we've shrunken the size of the slip of paper that says "heads", making it less likely to be drawn and we've increased the size of the slip of paper saying "tails", making it more likely to be drawn.
+When we simulated the fair coin, both slips of paper were the same size.
+This happens by default if you don't provide a [prob]{.monospace} argument; all elements in the [outcomes]{.monospace} vector have an equal probability of being drawn.
+
+If you want to learn more about `sample()` or any other function, recall that you can always check out its help file.
+
+```r
+?sample
+```
+
+## Simulating the Independent Shooter
+
+Simulating a basketball player who has independent shots uses the same mechanism that we use to simulate a coin flip.
+To simulate a single shot from an independent shooter with a shooting percentage of 50% we type,
+
+```r
+shot_outcomes <- c("H", "M")
+sim_basket <- sample(shot_outcomes, size = 1, replace = TRUE)
+```
+
+To make a valid comparison between Kobe and our simulated independent shooter, we need to align both their shooting percentage and the number of attempted shots.
+
+@.
+    What change needs to be made to the `sample()` function so that it reflects a shooting percentage of 45%?
+    Make this adjustment, then run a simulation to sample 133 shots.
+    Assign the output of this simulation to a new object called [sim_basket]{.monospace}.
+
+Note that we've named the new vector [sim_basket]{.monospace}, the same name that we gave to the previous vector reflecting a shooting percentage of 50%.
+In this situation, R overwrites the old object with the new one, so always make sure that you don't need the information in an old vector before reassigning its name.
+
+With the results of the simulation saved as [sim_basket]{.monospace}, we have the data necessary to compare Kobe to our independent shooter.
+
+Both data sets represent the results of 133 shot attempts, each with the same shooting percentage of 45%.
+We know that our simulated data is from a shooter that has independent shots.
+That is, we know the simulated shooter does not have a hot hand.
+
+## Additional exercises
+
+@.
+    Using `calc_streak()`, compute the streak lengths of [sim_basket]{.monospace}, and assign the results to a variable named [sim_streak]{.monospace}. Note that since the [sim_streak]{.monospace} object is just a vector and not a variable in a tibble, we don’t need to select it using the dollar sign symbol [\$]{.monospace} like we did earlier when we calculated the streak lengths for Kobe’s shots.
+
+@.
+    Describe the distribution of streak lengths. What is the typical streak length for this simulated independent shooter with a 45% shooting percentage?
+    How long is the player's longest streak of baskets in 133 shots?
+    Make sure to include a plot in your answer.
+
+@.
+    If you were to run the simulation of the independent shooter a second time, how would you expect its streak distribution to compare to the distribution from the question above?
+    Exactly the same?
+    Somewhat similar?
+    Totally different?
+    Explain your reasoning.
+
+@.
+    How does Kobe Bryant's distribution of streak lengths compare to the distribution of streak lengths for the simulated shooter?
+    Using this comparison, do you have evidence that the hot hand model fits Kobe's shooting patterns?
+    Explain.
+
+## How to submit
+
+To submit your lab, follow the two steps below.
+Your lab will be graded for credit **after** you've completed both steps!
+
+1.  Save, commit, and push your completed R Markdown file so that everything is synchronized to GitHub.
+    If you do this right, then you will be able to view your completed file on the GitHub website.
+
+2.  Knit your R Markdown document to the PDF format, export (download) the PDF file from RStudio Server, and then upload it to *`r lab_name`* posting on Blackboard.
+
+## Cheatsheets
+
+You are encouraged to review and keep the following cheatsheets handy while working on this lab:
+
+*   [data import/tidyr cheatsheet][data-import-cheatsheet]
+
+*   [dplyr cheatsheet][dplyr-cheatsheet]
+
+*   [ggplot2 cheatsheet][ggplot2-cheatsheet]
+
+*   [RStudio cheatsheet][rstudio-cheatsheet]
+
+*   [R Markdown cheatsheet][rmarkdown-cheatsheet]
+
+*   [R Markdown reference][rmarkdown-reference]
+
+## Credits
+
+This lab is a derivative of [OpenIntro Lab 4 -- Probability][openintro-lab-4] by Andrew Bray and Mine Çetinkaya-Rundel, which was adapted from a lab written by Mark Hansen of UCLA Statistics, used under [CC BY-SA 3.0][cc-by-sa-3].
+This lab is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa-4].
+Adapted by James Glasbrenner for CDS 102.
+
+[cc-by-sa-3]:             https://creativecommons.org/licenses/by-sa/3.0/
+[cc-by-sa-4]:             https://creativecommons.org/licenses/by-sa/4.0/
+[gilovich-paper]:         https://drive.google.com/file/d/1NN8ZRmk7ZUc5KeJl7PJfeUF0PRqG6hdR
+[r-infer-github]:         https://infer.netlify.com/
+[openintro-lab-4]:        https://htmlpreview.github.io/?https://github.com/andrewpbray/oiLabs-base-R/blob/master/probability/probability.html
+[dplyr-cheatsheet]:       https://github.com/rstudio/cheatsheets/raw/master/data-transformation.pdf
+[kobe-bryant-wiki]:       https://en.wikipedia.org/wiki/Kobe_Bryant
+[ggplot2-cheatsheet]:     https://www.rstudio.com/wp-content/uploads/2016/11/ggplot2-cheatsheet-2.1.pdf
+[rstudio-cheatsheet]:     https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf
+[rmarkdown-reference]:    https://www.rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf
+[2009-nba-finals-wiki]:   https://en.wikipedia.org/wiki/2009_NBA_Finals
+[rmarkdown-cheatsheet]:   https://github.com/rstudio/cheatsheets/raw/master/rmarkdown-2.0.pdf
+[data-import-cheatsheet]: https://github.com/rstudio/cheatsheets/raw/master/data-import.pdf 


### PR DESCRIPTION
The instructions and exercises for Lab 7 have been added to the course website. An instructions preamble has been added to the beginning of Lab 7, and the "About the dataset" section was slightly revised to better match the way datasets are introduced in the CDS 101 homeworks. The instructions were revised to use the infer package to simulate flipping a coin and an independent shooter and edited to improve clarify. Minor changes include,

- The "Additional questions" section has been renamed "Additional exercises"
- A list of relevant cheatsheets is linked at the end of the lab instructions