### PR TITLE
content(labs): update and revise lab 9

### DIFF
--- a/content/Labs/lab09-moneyball.Rmd
+++ b/content/Labs/lab09-moneyball.Rmd
@@ -11,22 +11,32 @@ Show_link: true
 ```{r setup, include = FALSE}
 suppressPackageStartupMessages(library(tidyverse))
 
-icon_pdf <- '<i class="fas fa-file-pdf" data-fa-transform="grow-16"></i>&nbsp;'
+icon_pdf <- '<i class="fas fa-file-pdf" data-fa-transform="grow-2"></i>&nbsp;'
+icon_link <- '<i class="fas fa-link"></i>'
 icon_github <- '<i class="fab fa-github-alt" data-fa-transform="grow-16"></i>&nbsp;'
+icon_link_bullet <- '<i class="fas fa-link" data-fa-transform="grow-2"></i>&nbsp;'
 lab_name <- "Lab 9"
+starter_file <- "lab09.Rmd"
 ```
 
-> This week's lab will show you how to build predictive models using linear regression and data collected on the 2011 Major League Baseball season.
+## Instructions
+
+Obtain the GitHub repository you will use to complete the lab, which contains a starter file named [`r starter_file`]{.monospace}.
+This lab shows you how to build predictive models using linear regression and data collected on the 2011 Major League Baseball season.
+Carefully read the lab instructions and complete the exercises using the provided spaces within your starter file [`r starter_file`]{.monospace}.
+Then, when you're ready to submit, follow the directions in the [`r icon_link`How to submit](#how-to-submit) section below.
 
 ## Data science in sports and at the movies
 
-The movie [Moneyball][moneyball-wiki] focuses on the "quest for the secret of success in baseball".
+The movie [`r icon_link`Moneyball][moneyball-wiki] focuses on the "quest for the secret of success in baseball".
 It follows a low-budget team, the Oakland Athletics, who believed that underused statistics, such as a player's ability to get on base, better predict the ability to score runs than typical statistics like home runs, RBIs (runs batted in), and batting average.
 Obtaining players who excelled in these underused statistics turned out to be much more affordable for the team.
 
-## About this week's dataset
+## About the dataset
 
 This dataset is the data from the 2011 Major League Baseball (MLB) season, containing several different kinds of summary statistics for the different teams.
+
+The table below provides descriptions of the dataset's 12 variables,
 
 | Variable                    | Description                                                         |
 | --------------              | ------------------------------------------------------              |
@@ -43,10 +53,13 @@ This dataset is the data from the 2011 Major League Baseball (MLB) season, conta
 | [new\_slug]{.monospace}     | Slugging percentage (total bases divided by [at\_bats]{.monospace}) |
 | [new\_obs]{.monospace}      | On-base plus slugging percentages                                   |
 
-The first seven variables, [at\_bats]{.monospace}, [hits]{.monospace}, [homeruns]{.monospace}, [bat\_avg]{.monospace}, [strikeouts]{.monospace}, [stolen\_bases]{.monospace}, and [wins]{.monospace}, are the [traditionally used variables][traditional-baseball-statistics] for baseball statistics.
-The last three variables, [new\_onbase]{.monospace}, [new\_slug]{.monospace}, and [new\_obs]{.monospace}, are the suggested variables that the author of *Moneyball* claims were better predictors of the [runs]{.monospace} variable.
+## Variables for baseball statistics
 
-@.  What type of plot would you use to display the relationship between [runs]{.monospace} and one of the other numerical variables?
+The first seven variables, [at\_bats]{.monospace}, [hits]{.monospace}, [homeruns]{.monospace}, [bat\_avg]{.monospace}, [strikeouts]{.monospace}, [stolen\_bases]{.monospace}, and [wins]{.monospace}, are the [`r icon_link`traditionally used variables][traditional-baseball-statistics] for baseball statistics.
+The last three variables, [new\_onbase]{.monospace}, [new\_slug]{.monospace}, and [new\_obs]{.monospace}, are the suggested variables that the author of _Moneyball_ claims were better predictors of the [runs]{.monospace} variable.
+
+@.  
+    What type of plot would you use to display the relationship between [runs]{.monospace} and one of the other numerical variables?
     Plot this relationship using the variable [at\_bats]{.monospace} as the explanatory variable (horizontal axis).
     Does the relationship look linear?
     Explain what you've noticed in the plot that makes you think the relationship is linear (or not linear).
@@ -65,7 +78,7 @@ The first argument in the function [lm]{.monospace} is a formula that takes the 
 Here it can be read that we want to make a linear model of [runs]{.monospace} as a function of [at\_bats]{.monospace}.
 The second argument specifies that R should look in the [mlb11]{.monospace} data frame to find the [runs]{.monospace} and [at\_bats]{.monospace} variables.
 
-Having assigned the model to [runs\_at\_bats\_model]{.monospace}, we can use a couple of convenience functions from the handy [broom]{.monospace} package --- this was installed when we installed [tidyverse]{.monospace} --- to get a basic overview of the model.
+Having assigned the model to [runs\_at\_bats\_model]{.monospace}, we can use a couple of convenience functions from the handy [broom]{.monospace} package to get a basic overview of the model.
 To get a data frame summarizing the model parameters, we use the `tidy()` function,
 
 ```r
@@ -75,7 +88,7 @@ runs_at_bats_model %>%
 
 This table contains the model coefficients, with the first column pertaining to the linear model's y-intercept and the coefficient (slope) of [at_bats]{.monospace}.
 With this table, we can write down the formal expression for the least squares regression line for our linear model:
-\\[\text{runs}(\text{at\_bats})=-2789.2429+0.6305\times\text{at\_bats}\\]
+$$\text{runs}(\text{at\_bats})=-2789.2429+0.6305\times\text{at\_bats}$$
 
 Additional information about the model, such as the model's $R^2$ paramter, can be obtained using the `glance()` function:
 
@@ -87,7 +100,8 @@ runs_at_bats_model %>%
 The $R^2$ value represents the proportion of variability in the response variable that is explained by the explanatory variable.
 For this model, 37.3% of the variability in runs is explained by [at\_bats]{.monospace}.
 
-@.  Fit a new model that uses [homeruns]{.monospace} to predict [runs]{.monospace} and obtain the coefficients and other details about the model using `tidy()` and `glance()`.
+@.  
+    Fit a new model that uses [homeruns]{.monospace} to predict [runs]{.monospace} and obtain the coefficients and other details about the model using `tidy()` and `glance()`.
     What do the intercept and the slope tell us about the relationship between the success of a team and the number of home runs its players hit during the season?
 
 ## Prediction and prediction errors
@@ -115,14 +129,14 @@ ggplot(data = runs_at_bats_df) +
 ```
 
 Although the [pred]{.monospace} column in [runs\_at\_bats\_df]{.monospace} only corresponds to predictions for the input values of the [at\_bats]{.monospace} column, in general the model allows us to predict the value of [runs]{.monospace} at **any** value of [at\_bats]{.monospace}, including values that are outside the range $[5417, 5710]$.
-Predictions beyond the range of the observed data is referred to as *extrapolation*, and making strong predictions based on extrapolation is not recommended.
+Predictions beyond the range of the observed data is referred to as _extrapolation_, and making strong predictions based on extrapolation is not recommended.
 Predictions made within the range of the data are considered more reliable.
 
 You have a couple of options available if you want to make predictions at values of [at\_bats]{.monospace} not found in the [mlb11]{.monospace} data frame.
 If you are interested in a few specific points, then you can build a data frame by hand and pipe it into `add_predictions()`,
 
 ```r
-runs_at_bats_more_pred <- tibble(   (  # Creates a data frame with a column
+runs_at_bats_more_pred <- tibble(      # Creates a data frame with a column
   at_bats = combine(5400, 5650)        # named at_bats with two values, 5400
 ) %>%                                  # and 5650
   add_predictions(runs_at_bats_model)
@@ -150,7 +164,8 @@ runs_at_bats_seq_pred <- tibble(      # Creates a data frame with a column
 As discussed earlier, the prediction error is defined as the difference between the predicted value and the observed value is called the **residual**.
 Visually, the residual is the vertical distance from the model line to each data point.
 
-@.  Use the following code to visualize the residuals connected to each data point,
+@.
+    Use the following code to visualize the residuals connected to each data point,
     
     ```r
     ggplot(runs_at_bats_df) +
@@ -180,7 +195,8 @@ runs_at_bats_df2 <- runs_at_bats_df %>%
 
 The residuals are added as a new column named [resid]{.monospace}.
 
-@.  Create a histogram of the residuals stored in [runs\_at\_bats\_df2]{.monospace}.
+@.  
+    Create a histogram of the residuals stored in [runs\_at\_bats\_df2]{.monospace}.
     Make sure you choose an appropriate bin width for the distribution.
     What is the shape and center of the residuals?
 
@@ -188,13 +204,11 @@ The residuals are added as a new column named [resid]{.monospace}.
 
 Three conditions must be met in order for a linear model built using `lm()` to be reliable:
 
-:::::{.additional-questions}
 *  **Linearity:** The relationship between the explanatory variable and the response variable must be linear
 
 *  **Nearly normal residuals:** The residuals should be nearly normal (i.e. follow a bell curve shape)
 
 *  **Constant variability:** The variability of the points around the model line should be roughly constant
-:::::
 
 Let's walk through each of the three conditions and discuss what we can plot to help us assess whether the linear model is reliable.
 
@@ -231,7 +245,8 @@ One such method is to build a Q-Q plot using `geom_qq()`, which is designed to s
 A reference line should also be included in the Q-Q plot, which we can do by using `geom_qq_line()`.
 Any points found on this line are following a normal distribution and any points away from the line are deviating from the normal distribution.
 
-@.  Create a Q-Q plot of the model's residuals using the following code:
+@.  
+    Create a Q-Q plot of the model's residuals using the following code:
 
     ```r
     ggplot(data = runs_at_bats_df2) +
@@ -246,21 +261,22 @@ Any points found on this line are following a normal distribution and any points
 The residual versus predicted plot you created in **Exercise @resid-or-obs-vs-pred-plots** can be used to determine whether the variability of the points around the model line remain approximately constant.
 If the residual spread seems to increase or decrease as the predicted value changes, then this condition is violated.
 
-@.  Interpret the residual versus predicted plot from **Exercise @resid-or-obs-vs-pred-plots** and conclude whether the constant variability condition is met.
+@.  
+    Interpret the residual versus predicted plot from **Exercise @resid-or-obs-vs-pred-plots** and conclude whether the constant variability condition is met.
 
-## Additional questions
+## Additional exercises
 
-:::::{.additional-questions}
-*   Choose another traditional variable from [mlb11]{.monospace} that you think might be a good predictor of [runs]{.monospace}.
+@.  
+    Choose another traditional variable from [mlb11]{.monospace} that you think might be a good predictor of [runs]{.monospace}.
     Fit a linear model and create **observed versus predicted** and **residual versus predicted** plots (you do not need to check the conditions for using the linear model).
     Does your variable seem to predict [runs]{.monospace} better than [at\_bats]{.monospace}?
     Determine this by comparing the $R^2$ values (obtained using `glance()`) for the two models.
 
-*   Now use one of the three newer variables, [new\_onbase]{.monospace}, [new\_slug]{.monospace}, and [new\_obs]{.monospace}, to build a linear model using the same method as before.
-    These are the statistics used by the author of *Moneyball* to predict a teams success.
+@.  
+    Now use one of the three newer variables, [new\_onbase]{.monospace}, [new\_slug]{.monospace}, and [new\_obs]{.monospace}, to build a linear model using the same method as before.
+    These are the statistics used by the author of _Moneyball_ to predict a teams success.
     After fitting the model you should create **observed versus predicted** and **residual versus predicted** plots (you do not need to check the conditions for using the linear model) and also compare the new model's $R^2$ values (obtained using `glance()`) with the others.
     Based on what you find, conclude whether the new variable is more or less effective at predicting runs than the two older variables you investigated.
-:::::
 
 ## How to submit
 
@@ -272,14 +288,36 @@ Your lab will be graded for credit **after** you've completed both steps!
 
 2.  Knit your R Markdown document to the PDF format, export (download) the PDF file from RStudio Server, and then upload it to *`r lab_name`* posting on Blackboard.
 
+## Cheatsheets
+
+You are encouraged to review and keep the following cheatsheets handy while working on this lab:
+
+*   [data import/tidyr cheatsheet][data-import-cheatsheet]
+
+*   [dplyr cheatsheet][dplyr-cheatsheet]
+
+*   [ggplot2 cheatsheet][ggplot2-cheatsheet]
+
+*   [RStudio cheatsheet][rstudio-cheatsheet]
+
+*   [R Markdown cheatsheet][rmarkdown-cheatsheet]
+
+*   [R Markdown reference][rmarkdown-reference]
+
 ## Credits
 
-This lab, *Moneyball*, is a derivative of [OpenIntro Lab 9 – Introduction to linear regression][openintro-lab-9] by Andrew Bray and Mine Çetinkaya-Rundel, which was adapted from a lab written by the faculty and TAs of UCLA Statistics, used under [CC BY-SA 3.0][cc-by-sa-3].
-*Moneyball* is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa-4] by James Glasbrenner.
+This lab is a derivative of [OpenIntro Lab 9 – Introduction to linear regression][openintro-lab-9] by Andrew Bray and Mine Çetinkaya-Rundel, which was adapted from a lab written by the faculty and TAs of UCLA Statistics, used under [CC BY-SA 3.0][cc-by-sa-3].
+This lab is licensed under a [Creative Commons Attribution-ShareAlike 4.0 International License][cc-by-sa-4].
+Adapted by James Glasbrenner for CDS 102.
 
 [cc-by-sa-3]:                      https://creativecommons.org/licenses/by-sa/3.0/
 [cc-by-sa-4]:                      http://creativecommons.org/licenses/by-sa/4.0/
 [moneyball-wiki]:                  http://en.wikipedia.org/wiki/Moneyball_(film)
 [openintro-lab-9]:                 https://htmlpreview.github.io/?https://github.com/andrewpbray/oiLabs-base-R/blob/master/simple_regression/simple_regression.html
-[univariate-description]:          http://stattrek.com/statistics/charts/data-patterns.aspx
+[dplyr-cheatsheet]:                https://github.com/rstudio/cheatsheets/raw/master/data-transformation.pdf
+[ggplot2-cheatsheet]:              https://www.rstudio.com/wp-content/uploads/2016/11/ggplot2-cheatsheet-2.1.pdf
+[rstudio-cheatsheet]:              https://github.com/rstudio/cheatsheets/raw/master/rstudio-ide.pdf
+[rmarkdown-reference]:             https://www.rstudio.com/wp-content/uploads/2015/03/rmarkdown-reference.pdf
+[rmarkdown-cheatsheet]:            https://github.com/rstudio/cheatsheets/raw/master/rmarkdown-2.0.pdf
+[data-import-cheatsheet]:          https://github.com/rstudio/cheatsheets/raw/master/data-import.pdf 
 [traditional-baseball-statistics]: https://en.wikipedia.org/wiki/Baseball_statistics#Commonly_used_statistics


### PR DESCRIPTION
An instructions preamble has been added to the beginning of Lab 9, and the "About the dataset" section was revised to better match the way datasets are introduced in the CDS 101 homeworks. The lab instructions in general have been edited and revised to improve
clarity. Other minor changes include,

- The "Additional questions" section has been renamed "Additional exercises"
- A list of relevant cheatsheets is linked at the end of the lab instructions